### PR TITLE
Change example to single quotes for rubocop happiness

### DIFF
--- a/rules.yml
+++ b/rules.yml
@@ -63,7 +63,7 @@ rules:
         text: 'This modified example would not match the FC003 rule:'
         code: |
           if Chef::Config[:solo]
-            Chef::Log.warn("This recipe uses search. Chef Solo does not support search.")
+            Chef::Log.warn('This recipe uses search. Chef Solo does not support search.')
           else
             nodes = search(:node, "hostname:[* TO *] AND chef_environment:#{node.chef_environment}")
           end


### PR DESCRIPTION
When copying and pasting this example, it would be great if it had single-quotes by default, so that rubocop doesn't immediately complain about it. 

Thanks!
@martinb3