### PR TITLE
Make formatting consistent (Erb vs erb)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.docset
 docset/build
 source/dash/Foodcritic.tgz
+.project

--- a/api_methods.yml
+++ b/api_methods.yml
@@ -336,7 +336,7 @@ api_methods:
           True if this string might be an OS command
   - name: read_ast
     description: |
-      Read the AST for the given Ruby or Erb source file.
+      Read the AST for the given Ruby or erb source file.
 
       Many of the other functions documented here take an `ast` as an argument.
       You can also use Nokogiri's support querying the AST with XPath or CSS


### PR DESCRIPTION
This pull request is to make the formatting consistent between [erb](https://github.com/acrmp/foodcritic-site/blob/5e2fdc8d55a86d8ab5b575b2eb893bfb2cce667d/rules.yml#L974) and [Erb](https://github.com/acrmp/foodcritic-site/blob/5e2fdc8d55a86d8ab5b575b2eb893bfb2cce667d/api_methods.yml#L339).

Also added `.project` to the `.gitignore` for those editing in Eclipse.