### PR TITLE
Update code for FC003 so it passes Rubocop linting

### DIFF
--- a/rules.yml
+++ b/rules.yml
@@ -63,7 +63,7 @@ rules:
         text: 'This modified example would not match the FC003 rule:'
         code: |
           if Chef::Config[:solo]
-            Chef::Log.warn("This recipe uses search. Chef Solo does not support search.")
+            Chef::Log.warn('This recipe uses search. Chef Solo does not support search.')
           else
             nodes = search(:node, "hostname:[* TO *] AND chef_environment:#{node.chef_environment}")
           end


### PR DESCRIPTION
This is pretty minor. I copied your code example verbatim but unfortunately Rubocop complains about the quoting. Kind of funny to fix one lint issue and have another pop up :)

```
Prefer single-quoted strings when you don't need string interpolation or special symbols.
  Chef::Log.warn("This recipe uses search. Chef Solo does not support search.")
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```